### PR TITLE
Reorder Opaque to minimize bytes on the wire

### DIFF
--- a/schema/common.capnp
+++ b/schema/common.capnp
@@ -32,8 +32,8 @@ struct SystemCallTarget {
 
 struct Opaque(Type) {
    union {
-      native @0 :Type;
-      bytes  @1 :Data $Json.base64;
+      bytes  @0 :Data $Json.base64;
+      native @1 :Type;
    }
 }
 


### PR DESCRIPTION
According to [here](https://capnproto.org/encoding.html) zero bytes are more efficiently encoded by the packing algorithm.

Since Opaque should always use the `bytes` member on the wire, we can reduce the packed size by having `bytes` be option 0.
