### PR TITLE
Embedd error_data in a one of

### DIFF
--- a/koinos/chain/chain.proto
+++ b/koinos/chain/chain.proto
@@ -6,13 +6,15 @@ option go_package = "github.com/koinos/koinos-proto-golang/koinos/chain";
 import "koinos/options.proto";
 import "koinos/common.proto";
 
-message result {
-   int32 code = 1;
-   bytes value = 2;
+message error_data {
+   string message = 1;
 }
 
-message error_info {
-   string message = 1;
+message result {
+   oneof value {
+      bytes object = 1;
+      error_data error = 2;
+   }
 }
 
 message object_space {

--- a/koinos/chain/system_calls.proto
+++ b/koinos/chain/system_calls.proto
@@ -69,9 +69,7 @@ message pre_transaction_callback_result {}
 
 message post_transaction_callback_arguments {}
 
-message post_transaction_callback_result {
-   result value = 1;
-}
+message post_transaction_callback_result {}
 
 message get_chain_id_arguments {}
 
@@ -339,7 +337,7 @@ message call_arguments {
 }
 
 message call_result {
-   bytes value = 1;
+   result value = 1;
 }
 
 message get_arguments_arguments {}
@@ -349,7 +347,8 @@ message get_arguments_result {
 }
 
 message exit_arguments {
-   result retval = 1;
+   int32 code = 1;
+   result res = 2;
 }
 
 message exit_result {}


### PR DESCRIPTION
Resolves koinos/koinos-chain#694

## Brief description

Refactor `result` to be a oneof object bytes or error_data.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

