### PR TITLE
Build EmbeddedProto with `negative-enums` branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       - PROTOBUF_VERSION="3.17.3"
       - GO_VERSION="1.16.6"
-      - PB_EMBEDDED_CPP_VERSION="field-options-hack"
+      - PB_EMBEDDED_CPP_VERSION="negative-enums"
       - NODE_VERSION="16.14.2"
       - AS_PROTO_VERSION="0.4.2"
 


### PR DESCRIPTION
Resolves koinos/koinos-sdk-as#34

## Brief description

Uses a branch of `EmbeddedProto` that correctly generate signed integer enums

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

https://github.com/koinos/koinos-proto-embedded-cpp/blob/e2fcdaddb0ff7caf547db2d92f7978c1052966d0/libraries/proto_embedded/generated/koinos/chain/error.h#L41-L66
