### PR TITLE
`head` flag on `block_accepted`

### DIFF
--- a/koinos/broadcast/broadcast.proto
+++ b/koinos/broadcast/broadcast.proto
@@ -28,6 +28,7 @@ message block_accepted {
    protocol.block block = 1;
    protocol.block_receipt receipt = 2;
    bool live = 3;
+   bool head = 4;
 }
 
 message block_irreversible {


### PR DESCRIPTION
## Brief description
Add a flag to indicate whether an accepted block is the new head or not.
