### PR TITLE
Add quantum_length to consensus_parameters and make fields uint32

### DIFF
--- a/koinos/contracts/pob/pob.proto
+++ b/koinos/contracts/pob/pob.proto
@@ -6,9 +6,10 @@ option go_package = "github.com/koinos/koinos-proto-golang/koinos/contracts/pob"
 import "koinos/options.proto";
 
 message consensus_parameters {
-   uint64 target_annual_inflation_rate = 1 [jstype = JS_STRING];
-   uint64 target_burn_percent = 2 [jstype = JS_STRING];
-   uint64 target_block_interval = 3 [jstype = JS_STRING];
+   uint32 target_annual_inflation_rate = 1;
+   uint32 target_burn_percent = 2;
+   uint32 target_block_interval = 3;
+   uint32 quantum_length = 4;
 }
 
 message public_key_record {


### PR DESCRIPTION
## Brief description

Adds `quantum_length` to encode all parameters and reduce size of 32 bit to match expected value range.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

