### PR TITLE
Explicitly require the producer address when registering a public key

### DIFF
--- a/koinos/contracts/pob/pob.proto
+++ b/koinos/contracts/pob/pob.proto
@@ -34,7 +34,8 @@ message vrf_payload {
 }
 
 message register_public_key_arguments {
-   bytes public_key = 1 [(btype) = BASE64];
+   bytes producer = 1 [(btype) = ADDRESS];
+   bytes public_key = 2 [(btype) = BASE64];
 }
 
 message register_public_key_result {}


### PR DESCRIPTION
## Brief description

Explicitly require the producer address when registering a public key

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
