### PR TITLE
Adds `pre_block_irreversibility` error code

### DIFF
--- a/koinos/chain/error.proto
+++ b/koinos/chain/error.proto
@@ -51,4 +51,5 @@ enum error_code {
     network_bandwidth_limit_exceeded = -1012;
     compute_bandwidth_limit_exceeded = -1013;
     disk_storage_limit_exceeded      = -1014;
+    pre_irreversibility_block        = -1015;
 }


### PR DESCRIPTION
## Brief description
Adds an error to indicate a block is prior to irreversibility.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

