### PR TITLE
Remove minimum block time from pob consensus parameters

### DIFF
--- a/koinos/contracts/pob/pob.proto
+++ b/koinos/contracts/pob/pob.proto
@@ -10,7 +10,6 @@ message consensus_parameters {
    uint32 target_burn_percent = 2;
    uint32 target_block_interval = 3;
    uint32 quantum_length = 4;
-   uint64 minimum_block_time = 5;
 }
 
 message public_key_record {


### PR DESCRIPTION
## Brief description

Removes the unused minimum block parameter.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
