### PR TITLE
Add a Dockerfile capable of building all targets #170

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.16-alpine AS builder
+
+RUN apk update && \
+    apk add \
+        curl \
+        git \
+        nodejs \
+        npm \
+        protoc \
+        python3 \
+        rsync \
+        yarn
+
+ADD . /koinos-proto
+WORKDIR /koinos-proto
+
+ENV PROTOBUF_VERSION="3.17.3"
+ENV PB_EMBEDDED_CPP_VERSION="negative-enums"
+ENV NODE_VERSION="16.14.2"
+ENV AS_PROTO_VERSION="0.4.2"
+
+RUN /koinos-proto/docker-scripts/install.sh
+RUN /koinos-proto/docker-scripts/build.sh
+RUN /koinos-proto/docker-scripts/generate_bundle.sh

--- a/docker-scripts/build.sh
+++ b/docker-scripts/build.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -e
+set -x
+
+mkdir -p \
+   /koinos-proto-build/cpp \
+   /koinos-proto-build/go \
+   /koinos-proto-build/js \
+   /koinos-proto-build/python \
+   /koinos-proto-build/eams \
+   /koinos-proto-build/docs \
+   /koinos-proto-build/as
+
+KOINOS_PROTOS=$(find /koinos-proto/koinos -name "*.proto")
+GOOGLE_PROTOS=$(find /koinos-proto/google -name "*.proto")
+RPC_PROTOS=$(find /koinos-proto/koinos -name "*rpc*.proto")
+
+protoc --experimental_allow_proto3_optional \
+   -I/koinos-proto \
+   --cpp_out=/koinos-proto-build/cpp/ \
+   --go_out=/koinos-proto-build/go/ \
+   --python_out=/koinos-proto-build/python \
+   --descriptor_set_out=/koinos-proto-build/koinos_descriptors.pb \
+   --plugin=protoc-gen-as=/koinos-proto-build/js/node_modules/.bin/as-proto-gen \
+   --as_out=/koinos-proto-build/as \
+   $KOINOS_PROTOS
+
+protoc --experimental_allow_proto3_optional \
+   -I/koinos-proto \
+   --doc_out=/koinos-proto-build/docs --doc_opt=markdown,api.md \
+   $RPC_PROTOS
+
+protoc --experimental_allow_proto3_optional \
+   -I/koinos-proto \
+   --plugin=/koinos-proto/docker-scripts/protoc-gen-eams \
+   --eams_out=/koinos-proto-build/eams \
+   $KOINOS_PROTOS
+
+cd /koinos-proto-build/js
+
+yarn pbjs  --keep-case --target static-module -o /koinos-proto-build/js/index.js $KOINOS_PROTOS $GOOGLE_PROTOS
+yarn pbts -o /koinos-proto-build/js/index.d.ts /koinos-proto-build/js/index.js
+yarn pbjs  --keep-case --target json -o /koinos-proto-build/js/index.json $KOINOS_PROTOS $GOOGLE_PROTOS

--- a/docker-scripts/generate_bundle.sh
+++ b/docker-scripts/generate_bundle.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -e
+set -x
+
+OUTDIR=/koinos-proto-build/out
+
+# C++
+mkdir -p "$OUTDIR/koinos-proto-cpp/libraries/proto/generated/"
+rsync -rvm --include "*.pb.h" --include "*.pb.cc" --include "*/" --exclude "*" /koinos-proto-build/cpp/ "$OUTDIR/koinos-proto-cpp/libraries/proto/generated/"
+
+# golang
+mkdir -p "$OUTDIR/koinos-proto-golang/"
+rsync -rvm --include "*.pb.go" --include "*/" --exclude "*" /koinos-proto-build/go/ "$OUTDIR/koinos-proto-golang/"
+
+# js/ts
+mkdir -p "$OUTDIR/koinos-proto-js/"
+rsync -vm --include "index.js" --include "index.d.ts" --include="index.json" --exclude "*" /koinos-proto-build/js/ "$OUTDIR/koinos-proto-js/"
+
+# python
+mkdir -p "$OUTDIR/koinos-proto-python/"
+rsync -rvm --include "*_pb2.py" --include "*/" --exclude "*" /koinos-proto-build/python/ "$OUTDIR/koinos-proto-python/"
+
+# embedded-cpp
+mkdir -p "$OUTDIR/koinos-proto-embedded-cpp/libraries/proto_embedded/generated/"
+rsync -rvm --include "*.h" --include "*/" --exclude "*" /koinos-proto-build/eams/ "$OUTDIR/koinos-proto-embedded-cpp/libraries/proto_embedded/generated/"
+mkdir -p "$OUTDIR/koinos-proto-embedded-cpp/libraries/proto_embedded/src/"
+rsync -rvm --include "*.h" --include "*.cpp" --include "*/" --exclude "*" /koinos-proto-build/EmbeddedProto/src/ "$OUTDIR/koinos-proto-embedded-cpp/libraries/proto_embedded/src/"
+
+# docs
+mkdir -p "$OUTDIR/koinos-proto-documentation"
+rsync -rvm --include "*.md" /koinos-proto-build/docs "$OUTDIR/koinos-proto-documentation"
+
+# descriptors
+mkdir -p "$OUTDIR/koinos-proto-descriptors"
+cp /koinos-proto-build/koinos_descriptors.pb "$OUTDIR/koinos-proto-descriptors/koinos_descriptors.pb"
+
+# as
+mkdir -p "$OUTDIR/koinos-proto-as/assembly/koinos"
+rsync -rvm --include "*.ts" --include "*/" --exclude "*" /koinos-proto-build/as/koinos/ "$OUTDIR/koinos-proto-as/assembly/koinos"
+
+(cd /koinos-proto-build/out && tar c * | gzip -c9) > /koinos-proto-generated.tar.gz

--- a/docker-scripts/install.sh
+++ b/docker-scripts/install.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+set -x
+
+mkdir -p /koinos-proto-build
+cd /koinos-proto-build
+
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.0
+
+git clone --recursive https://github.com/koinos/EmbeddedProto /koinos-proto-build/EmbeddedProto
+
+cd /koinos-proto-build/EmbeddedProto
+git checkout $PB_EMBEDDED_CPP_VERSION
+sh ./setup.sh
+
+mkdir -p /koinos-proto-build/js
+cd /koinos-proto-build/js
+yarn add protobufjs@^6.11.3
+yarn add @koinos/as-proto-gen@$AS_PROTO_VERSION
+yarn global add @jsdevtools/version-bump-prompt

--- a/docker-scripts/protoc-gen-eams
+++ b/docker-scripts/protoc-gen-eams
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /koinos-proto-build/EmbeddedProto/venv/bin/python /koinos-proto-build/EmbeddedProto/generator/protoc-gen-eams.py --protoc-plugin


### PR DESCRIPTION
Some work on a Dockerfile.  See #170.

## Brief description

Initial attempt at implementing a Dockerfile.  Basically Dockerizing the existing Travis scripts.

Has some shortcomings:

- Version pinning is not exactly the same as CI scripts
- Downloading binaries doesn't work with Alpine (glibc vs. musl issue, I believe), so I used the Alpine package manager for e.g. Yarn / Node
- Does not interface with CI scripts in any way
- Outputs a tarball in the root directory

Merging this should be harmless, as it strictly adds files; no existing scripts are changed.

Ideally a Travis guru should adapt the CI scripts to build the Dockerfile and upload the output to the relevant places.  Local and CI builds should share as much infrastructure as possible (anything else defeats the point of having CI).

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration

```
# docker build . -t koinos-proto:latest
... lots of output ...
Successfully tagged koinos-proto:latest

# docker run -it --rm koinos-proto /bin/sh
/koinos-proto # ls -al /*.gz
-rw-r--r--    1 root     root        777648 Nov 21 20:12 /koinos-proto-generated.tar.gz

/koinos-proto # tar tzvf /koinos-proto-generated.tar.gz | less
drwxr-xr-x root/root         0 2022-11-21 20:12:25 koinos-proto-as/
drwxr-xr-x root/root         0 2022-11-21 20:12:25 koinos-proto-as/assembly/
drwxr-xr-x root/root         0 2022-11-21 20:12:25 koinos-proto-as/assembly/koinos/
-rw-r--r-- root/root       185 2022-11-21 20:12:25 koinos-proto-as/assembly/koinos/options.ts
-rw-r--r-- root/root      1559 2022-11-21 20:12:25 koinos-proto-as/assembly/koinos/common.ts
drwxr-xr-x root/root         0 2022-11-21 20:12:25 koinos-proto-as/assembly/koinos/contracts/
drwxr-xr-x root/root         0 2022-11-21 20:12:25 koinos-proto-as/assembly/koinos/contracts/vhp/
-rw-r--r-- root/root      4455 2022-11-21 20:12:25 koinos-proto-as/assembly/koinos/contracts/vhp/vhp.ts
... lots of output ...
-rw-r--r-- root/root     32946 2022-11-21 20:12:25 koinos-proto-python/koinos/chain/chain_pb2.py
-rw-r--r-- root/root      8949 2022-11-21 20:12:25 koinos-proto-python/koinos/chain/authority_pb2.py
-rw-r--r-- root/root      5304 2022-11-21 20:12:25 koinos-proto-python/koinos/chain/events_pb2.py
-rw-r--r-- root/root     12591 2022-11-21 20:12:25 koinos-proto-python/koinos/chain/error_pb2.py
drwxr-xr-x root/root         0 2022-11-21 20:12:25 koinos-proto-python/koinos/account_history/
-rw-r--r-- root/root     11527 2022-11-21 20:12:25 koinos-proto-python/koinos/account_history/account_history_pb2.py
drwxr-xr-x root/root         0 2022-11-21 20:12:25 koinos-proto-python/koinos/broadcast/
-rw-r--r-- root/root     20056 2022-11-21 20:12:25 koinos-proto-python/koinos/broadcast/broadcast_pb2.py
drwxr-xr-x root/root         0 2022-11-21 20:12:25 koinos-proto-python/koinos/contract_meta_store/
-rw-r--r-- root/root      2504 2022-11-21 20:12:25 koinos-proto-python/koinos/contract_meta_store/contract_meta_store_pb2.py
```