### PR TITLE
Swap the order of fields in the `register_public_key event`

### DIFF
--- a/koinos/contracts/pob/pob.proto
+++ b/koinos/contracts/pob/pob.proto
@@ -62,8 +62,8 @@ message get_metadata_result {
 }
 
 message register_public_key_event {
-   bytes public_key = 1 [(btype) = BASE64];
-   bytes address = 2 [(btype) = ADDRESS];
+   bytes address = 1 [(btype) = ADDRESS];
+   bytes public_key = 2 [(btype) = BASE64];
 }
 
 message get_public_key_arguments {


### PR DESCRIPTION
Resolves #190.

## Brief description
Fixes the ordering of the `register_public_key_event`.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

