### PR TITLE
rename field in `get_contract_metadata_result` into `value`

### DIFF
--- a/koinos/chain/system_calls.proto
+++ b/koinos/chain/system_calls.proto
@@ -171,7 +171,7 @@ message get_contract_metadata_arguments {
 }
 
 message get_contract_metadata_result {
-   contract_metadata_object contract_metadata = 1;
+   contract_metadata_object value = 1;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Brief description
Rename the `get_contract_metadata_result` `contract_metadata` field into `value` to comply with other syscalls format.

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests