### PR TITLE
Simplify branch cleanup

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -7,12 +7,12 @@ jobs:
     if: github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
     env:
-      KOINOS_CI_TOKEN: ${{ secrets.KOINOS_CI_TOKEN }}
+      BRANCH_CLEANUP_TOKEN: ${{ secrets.BRANCH_CLEANUP_TOKEN }}
     steps:
       - run: |
           for lang in cpp golang js python embedded-cpp descriptors as
           do
-            REPO_URL="https://$KOINOS_CI_TOKEN@github.com/koinos/koinos-proto-$lang.git"
+            REPO_URL="https://$BRANCH_CLEANUP_TOKEN@github.com/koinos/koinos-proto-$lang.git"
 
             REMOTE_REF=$(git ls-remote --heads $REPO_URL ${{ github.event.ref }})
             if [[ $REMOTE_REF ]];  then

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -12,7 +12,7 @@ jobs:
       - run: |
           for lang in cpp golang js python embedded-cpp descriptors as
           do
-            REPO_URL="https://$BRANCH_CLEANUP_TOKEN@github.com/koinos/koinos-proto-$lang.git"
+            REPO_URL="https://koinos-ci:$BRANCH_CLEANUP_TOKEN@github.com/koinos/koinos-proto-$lang.git"
 
             REMOTE_REF=$(git ls-remote --heads $REPO_URL ${{ github.event.ref }})
             if [[ $REMOTE_REF ]];  then

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -12,13 +12,10 @@ jobs:
       - run: |
           for lang in cpp golang js python embedded-cpp descriptors as
           do
-            repo=koinos-proto-$lang
-            git clone https://$KOINOS_CI_TOKEN@github.com/koinos/${repo}.git
+            REPO_URL="https://$KOINOS_CI_TOKEN@github.com/koinos/koinos-proto-$lang.git"
 
-            pushd $repo
-            exists_in_remote=$(git ls-remote --heads origin ${{ github.event.ref }})
-            if [[ ${exists_in_remote} ]];  then
-              git push https://$KOINOS_CI_TOKEN@github.com/koinos/${repo}.git --delete ${{ github.event.ref }}
+            REMOTE_REF=$(git ls-remote --heads $REPO_URL ${{ github.event.ref }})
+            if [[ $REMOTE_REF ]];  then
+              git push $REPO_URL :${{ github.event.ref }}
             fi
-            popd
           done


### PR DESCRIPTION
Resolves <!-- Issue number(s) in the form #1 or org/repo#1 -->

## Brief description

Simplifies the branch cleanup (no clone). The failures appeared to be from a bad token. I have tested the commands locally with the a fine grained token expiring Jan 1, 2025.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
