### PR TITLE
#225: Bump proto-cpp version when proto is tagged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,13 @@ jobs:
         - rsync -rvm --include "*.pb.cc" --include "*/" --exclude "*" --delete ${TRAVIS_BUILD_DIR}/build/ src/
         - rsync -rvm --include "*.pb.h"  --include "*/" --exclude "*" --delete ${TRAVIS_BUILD_DIR}/build/ include/
         - git add src include
+        - |
+          if ! [ -z "${TRAVIS_TAG}" ]; then
+            # Assumes vMAJOR.MINOR.PATCH style tag
+            VERSION=${TRAVIS_TAG:1}
+            sed -i -e "s|  VERSION .*|  VERSION $VERSION|g" CMakeLists.txt
+            git add CMakeLists.txt
+          fi
         - popd
 
     - name: "Embedded C++"


### PR DESCRIPTION
Resolves #225

## Brief description

Updates the proto-cpp version on a tag build.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
