### PR TITLE
Determine the correct branch as an env var 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - COMMIT_SHORT=`git rev-parse --short HEAD`
     - BRANCH=`if ! [ -z ${TRAVIS_TAG} ]; then echo -n master; else echo -n ${TRAVIS_BRANCH}; fi`
 
-# This build matric mixes global and build specific build stages to abstract common tasks.
+# This build matrix mixes global and build specific build stages to abstract common tasks.
 # There are several conventions in place to facilitate this.
 #
 # 1. The destination repo (e.g. koinos-proto-cpp) is set in the env var DEST_REPO.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - PROTOBUF_VERSION=3.17.3
     - PROTO_FILES=`find koinos -name '*.proto' && find google -name '*.proto' && find openapiv3 -name '*.proto'`
     - COMMIT_SHORT=`git rev-parse --short HEAD`
+    - BRANCH=`if ! [ -z ${TRAVIS_TAG} ]; then echo -n master; else echo -n ${TRAVIS_BRANCH}; fi`
 
 # This build matric mixes global and build specific build stages to abstract common tasks.
 # There are several conventions in place to facilitate this.
@@ -173,8 +174,8 @@ before_install:
   - git clone https://${GITHUB_USER_TOKEN}@github.com/koinos/${DEST_REPO}.git
   - pushd $DEST_REPO
   - |
-    if [ "${TRAVIS_BRANCH}" != "master" ] && [ -z "${TRAVIS_TAG}" ]; then
-      git checkout -b ${TRAVIS_BRANCH}
+    if [ "${BRANCH}" != "master" ]; then
+      git checkout -b ${BRANCH}
     fi
   - popd
 
@@ -183,7 +184,7 @@ after_success:
   - |
     if ! git diff --cached --quiet --exit-code; then
       git commit -m "Update for koinos-proto commit ${COMMIT_SHORT}"
-      git push --force https://${GITHUB_USER_TOKEN}@github.com/koinos/${DEST_REPO}.git ${TRAVIS_BRANCH}
+      git push --force https://${GITHUB_USER_TOKEN}@github.com/koinos/${DEST_REPO}.git ${BRANCH}
     fi
   - |
     if ! [ -z "${TRAVIS_TAG}" ]; then


### PR DESCRIPTION
## Brief description

TRAVIS_BRANCH can be set to the branch name, or a tag. This causes an error when updating the npm version because travis attempts to push the version update to the tag branch, not master.

This can be seen in CI logs, but also in the `koinos-proto-as` repos where they have the correct tags, with the correct versions. But all tags are detached heads and were never pushed to `master`.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
