### PR TITLE
Add mempool RPC to retrieve pending account rc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ jobs:
         - AS_PROTO_VERSION=1.0.1
       install:
         - yarn add --dev @koinos/as-proto-gen@$AS_PROTO_VERSION
-        - yarn global add @jsdevtools/version-bump-prompt
+        - sudo yarn global add @jsdevtools/version-bump-prompt
       script:
         - mkdir -p build
         - protoc --experimental_allow_proto3_optional --plugin=protoc-gen-as=./node_modules/.bin/as-proto-gen --as_out=build $PROTO_FILES
@@ -125,7 +125,7 @@ jobs:
         - PROTOBUFJS_VERSION=^6.11.3
       install:
         - yarn add --dev protobufjs@$PROTOBUFJS_VERSION
-        - yarn global add @jsdevtools/version-bump-prompt
+        - sudo yarn global add @jsdevtools/version-bump-prompt
       script:
         - mkdir -p build
         - yarn pbjs  --keep-case --target static-module -o build/index.js `find ./koinos -name '*.proto'` `find ./google -name '*.proto'`

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ dist: jammy
 addons:
   apt:
     update: true
+    packages:
+      - nodejs
 
 stages:
   - name: after_success

--- a/koinos/rpc/mempool/mempool_rpc.proto
+++ b/koinos/rpc/mempool/mempool_rpc.proto
@@ -44,12 +44,22 @@ message check_account_nonce_response {
    bool success = 1;
 }
 
+message get_pending_account_rc_request {
+   bytes account = 1 [(btype) = ADDRESS];
+   optional bytes block_id = 2 [(btype) = BLOCK_ID];
+}
+
+message get_pending_account_rc_response {
+   uint64 pending_rc = 1;
+}
+
 message mempool_request {
    oneof request {
       rpc.reserved_rpc reserved = 1;
       check_pending_account_resources_request check_pending_account_resources = 2;
       get_pending_transactions_request get_pending_transactions = 3;
       check_account_nonce_request check_account_nonce = 4;
+      get_pending_account_rc_request pending_account_rc = 5;
    }
 }
 
@@ -60,5 +70,6 @@ message mempool_response {
       check_pending_account_resources_response check_pending_account_resources = 3;
       get_pending_transactions_response get_pending_transactions = 4;
       check_account_nonce_response check_account_nonce = 5;
+      get_pending_account_rc_responsee pending_account_rc = 6;
    }
 }

--- a/koinos/rpc/mempool/mempool_rpc.proto
+++ b/koinos/rpc/mempool/mempool_rpc.proto
@@ -70,6 +70,6 @@ message mempool_response {
       check_pending_account_resources_response check_pending_account_resources = 3;
       get_pending_transactions_response get_pending_transactions = 4;
       check_account_nonce_response check_account_nonce = 5;
-      get_pending_account_rc_responsee pending_account_rc = 6;
+      get_pending_account_rc_response pending_account_rc = 6;
    }
 }

--- a/koinos/rpc/mempool/mempool_rpc.proto
+++ b/koinos/rpc/mempool/mempool_rpc.proto
@@ -44,13 +44,12 @@ message check_account_nonce_response {
    bool success = 1;
 }
 
-message get_pending_account_rc_request {
+message get_reserved_account_rc_request {
    bytes account = 1 [(btype) = ADDRESS];
-   optional bytes block_id = 2 [(btype) = BLOCK_ID];
 }
 
-message get_pending_account_rc_response {
-   uint64 pending_rc = 1;
+message get_reserved_account_rc_response {
+   uint64 rc = 1;
 }
 
 message mempool_request {
@@ -59,7 +58,7 @@ message mempool_request {
       check_pending_account_resources_request check_pending_account_resources = 2;
       get_pending_transactions_request get_pending_transactions = 3;
       check_account_nonce_request check_account_nonce = 4;
-      get_pending_account_rc_request pending_account_rc = 5;
+      get_reserved_account_rc_request get_reserved_account_rc = 5;
    }
 }
 
@@ -70,6 +69,6 @@ message mempool_response {
       check_pending_account_resources_response check_pending_account_resources = 3;
       get_pending_transactions_response get_pending_transactions = 4;
       check_account_nonce_response check_account_nonce = 5;
-      get_pending_account_rc_response pending_account_rc = 6;
+      get_reserved_account_rc_response get_reserved_account_rc = 6;
    }
 }


### PR DESCRIPTION
Related to koinos/koinos-mempool#101.

## Brief description
Adds an RPC call to retrieve pending account rc from the mempool.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
