### PR TITLE
NPM allow same version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
         - ./generate_index.sh
         - |
           if ! [ -z "${TRAVIS_TAG}" ]; then
-            npm version ${TRAVIS_TAG} --git-tag-version false
+            npm version ${TRAVIS_TAG} --allow-same-version --git-tag-version false
           fi
         - git add .
         - popd
@@ -139,7 +139,7 @@ jobs:
         - cp ${TRAVIS_BUILD_DIR}/build/index.json index.json
         - |
           if ! [ -z "${TRAVIS_TAG}" ]; then
-            npm version ${TRAVIS_TAG} --git-tag-version false
+            npm version ${TRAVIS_TAG} --allow-same-version --git-tag-version false
           fi
         - git add .
         - popd


### PR DESCRIPTION
## Brief description

When making proto releases, CI tags the version, but also fails. See the following:

https://app.travis-ci.com/github/koinos/koinos-proto/builds/272880003?serverType=git
https://app.travis-ci.com/github/koinos/koinos-proto/builds/272880321?serverType=git
https://app.travis-ci.com/github/koinos/koinos-proto/builds/272880323?serverType=git

And the version was still bumped (as desired):

https://github.com/koinos/koinos-proto-js/commit/34a9175101111025c8f4e9b951100ea184c4a6a1

This will allow npm version to succeed if the version is identical, making CI pass.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
