### PR TITLE
#263: Add get_pending_transaction_count and error

### DIFF
--- a/koinos/chain/error.proto
+++ b/koinos/chain/error.proto
@@ -4,54 +4,55 @@ package koinos.chain;
 option go_package = "github.com/koinos/koinos-proto-golang/v2/koinos/chain";
 
 enum error_code {
-    success                      =    0;
+    success                            =    0;
 
     // Reversions
-    reversion                    =    1;
+    reversion                          =    1;
 
-    internal_error               =  100;
-    system_authorization_failure =  101;
-    invalid_contract             =  102;
-    insufficient_privileges      =  103;
-    insufficient_rc              =  104;
-    insufficient_return_buffer   =  105;
-    unknown_thunk                =  106;
-    unknown_operation            =  107;
-    read_only_context            =  108;
+    internal_error                     =  100;
+    system_authorization_failure       =  101;
+    invalid_contract                   =  102;
+    insufficient_privileges            =  103;
+    insufficient_rc                    =  104;
+    insufficient_return_buffer         =  105;
+    unknown_thunk                      =  106;
+    unknown_operation                  =  107;
+    read_only_context                  =  108;
 
     // Failures
-    failure                      =   -1;
+    failure                            =   -1;
 
-    field_not_found              = -100;
-    unknown_hash_code            = -101;
-    unknown_dsa                  = -102;
-    unknown_system_call          = -103;
-    operation_not_found          = -104;
+    field_not_found                    = -100;
+    unknown_hash_code                  = -101;
+    unknown_dsa                        = -102;
+    unknown_system_call                = -103;
+    operation_not_found                = -104;
 
-    authorization_failure        = -200;
-    invalid_nonce                = -201;
-    invalid_signature            = -202;
-    malformed_block              = -203;
-    malformed_transaction        = -204;
-    block_resource_failure       = -205;
+    authorization_failure              = -200;
+    invalid_nonce                      = -201;
+    invalid_signature                  = -202;
+    malformed_block                    = -203;
+    malformed_transaction              = -204;
+    block_resource_failure             = -205;
+    pending_transaction_limit_exceeded = -206;
 
     // Framework failures
-    unknown_backend                  = -1000;
-    unexpected_state                 = -1001;
-    missing_required_arguments       = -1002;
-    unknown_previous_block           = -1003;
-    unexpected_height                = -1004;
-    block_state_error                = -1005;
-    state_merkle_mismatch            = -1006;
-    unexpected_receipt               = -1007;
-    rpc_failure                      = -1008;
-    pending_state_error              = -1009;
-    timestamp_out_of_bounds          = -1010;
-    indexer_failure                  = -1011;
-    network_bandwidth_limit_exceeded = -1012;
-    compute_bandwidth_limit_exceeded = -1013;
-    disk_storage_limit_exceeded      = -1014;
-    pre_irreversibility_block        = -1015;
+    unknown_backend                    = -1000;
+    unexpected_state                   = -1001;
+    missing_required_arguments         = -1002;
+    unknown_previous_block             = -1003;
+    unexpected_height                  = -1004;
+    block_state_error                  = -1005;
+    state_merkle_mismatch              = -1006;
+    unexpected_receipt                 = -1007;
+    rpc_failure                        = -1008;
+    pending_state_error                = -1009;
+    timestamp_out_of_bounds            = -1010;
+    indexer_failure                    = -1011;
+    network_bandwidth_limit_exceeded   = -1012;
+    compute_bandwidth_limit_exceeded   = -1013;
+    disk_storage_limit_exceeded        = -1014;
+    pre_irreversibility_block          = -1015;
 }
 
 message error_details {

--- a/koinos/rpc/mempool/mempool_rpc.proto
+++ b/koinos/rpc/mempool/mempool_rpc.proto
@@ -61,6 +61,15 @@ message get_pending_nonce_response {
    bytes nonce = 1;
 }
 
+message get_pending_transaction_count_request {
+   bytes payee = 1 [(btype) = ADDRESS];
+   optional bytes block_id = 2 [(btype) = BLOCK_ID];
+}
+
+message get_pending_transaction_count_response {
+   uint64 count = 1;
+}
+
 message mempool_request {
    oneof request {
       rpc.reserved_rpc reserved = 1;
@@ -69,6 +78,7 @@ message mempool_request {
       check_account_nonce_request check_account_nonce = 4;
       get_reserved_account_rc_request get_reserved_account_rc = 5;
       get_pending_nonce_request get_pending_nonce = 6;
+      get_pending_transaction_count_request get_pending_transaction_count = 7;
    }
 }
 
@@ -81,5 +91,6 @@ message mempool_response {
       check_account_nonce_response check_account_nonce = 5;
       get_reserved_account_rc_response get_reserved_account_rc = 6;
       get_pending_nonce_response get_pending_nonce = 7;
+      get_pending_transaction_count_response get_pending_transaction_count = 8;
    }
 }


### PR DESCRIPTION
Resolves #263

## Brief description

Adds `mempool.get_pending_transaction_count` and `pending_transaction_limit_exceeded` error.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
