### PR TITLE
get_pending_transactions_by_id

### DIFF
--- a/koinos/rpc/mempool/mempool_rpc.proto
+++ b/koinos/rpc/mempool/mempool_rpc.proto
@@ -64,6 +64,15 @@ message get_pending_transaction_count_response {
    uint64 count = 1;
 }
 
+message get_pending_transaction_request {
+   bytes transaction_id = 1 [(btype) = TRANSACTION_ID];
+   optional bytes block_id = 2 [(btype) = BLOCK_ID];
+}
+
+message get_pending_transaction_response {
+   koinos.mempool.pending_transaction pending_transaction = 1;
+}
+
 message mempool_request {
    oneof request {
       rpc.reserved_rpc reserved = 1;
@@ -73,6 +82,7 @@ message mempool_request {
       get_reserved_account_rc_request get_reserved_account_rc = 5;
       get_pending_nonce_request get_pending_nonce = 6;
       get_pending_transaction_count_request get_pending_transaction_count = 7;
+      get_pending_transaction_request get_pending_transaction = 8;
    }
 }
 
@@ -86,5 +96,6 @@ message mempool_response {
       get_reserved_account_rc_response get_reserved_account_rc = 6;
       get_pending_nonce_response get_pending_nonce = 7;
       get_pending_transaction_count_response get_pending_transaction_count = 8;
+      get_pending_transaction_response get_pending_transaction = 9;
    }
 }

--- a/koinos/rpc/mempool/mempool_rpc.proto
+++ b/koinos/rpc/mempool/mempool_rpc.proto
@@ -64,13 +64,13 @@ message get_pending_transaction_count_response {
    uint64 count = 1;
 }
 
-message get_pending_transaction_request {
-   bytes transaction_id = 1 [(btype) = TRANSACTION_ID];
+message get_pending_transactions_by_id_request {
+   repeated bytes transaction_ids = 1 [(btype) = TRANSACTION_ID];
    optional bytes block_id = 2 [(btype) = BLOCK_ID];
 }
 
-message get_pending_transaction_response {
-   koinos.mempool.pending_transaction pending_transaction = 1;
+message get_pending_transactions_by_id_response {
+   repeated koinos.mempool.pending_transaction pending_transactions = 1;
 }
 
 message mempool_request {
@@ -82,7 +82,7 @@ message mempool_request {
       get_reserved_account_rc_request get_reserved_account_rc = 5;
       get_pending_nonce_request get_pending_nonce = 6;
       get_pending_transaction_count_request get_pending_transaction_count = 7;
-      get_pending_transaction_request get_pending_transaction = 8;
+      get_pending_transactions_by_id_request get_pending_transactions_by_id = 8;
    }
 }
 
@@ -96,6 +96,6 @@ message mempool_response {
       get_reserved_account_rc_response get_reserved_account_rc = 6;
       get_pending_nonce_response get_pending_nonce = 7;
       get_pending_transaction_count_response get_pending_transaction_count = 8;
-      get_pending_transaction_response get_pending_transaction = 9;
+      get_pending_transactions_by_id_response get_pending_transactions_by_id = 9;
    }
 }


### PR DESCRIPTION
Resolves #267

## Brief description

Adds a mempool rpc to query pending transactions by id.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
